### PR TITLE
Feature/improve theme icon padding

### DIFF
--- a/app/components/common/navbar/components/NavLinks.tsx
+++ b/app/components/common/navbar/components/NavLinks.tsx
@@ -13,7 +13,7 @@ interface NavLinksProps {
 	isMobile?: boolean;
 }
 
-export function NavLinks({ isMobile = false }) {
+export function NavLinks({ isMobile = false }: NavLinksProps) {
 	let pages = ['about', 'projects', 'testimonials', 'contact'];
 	if (isMobile) pages = ['home'].concat(pages);
 

--- a/app/components/common/navbar/components/ThemePicker.tsx
+++ b/app/components/common/navbar/components/ThemePicker.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
-import { ThemePreference, useThemePreference } from '~/context';
+import type { ThemePreference } from '~/context';
+import { useThemePreference } from '~/context';
 import { Dropdown } from '~/components/radix';
-import { GlobeIcon, MoonIcon, SunIcon, LoadingIcon } from '~/components/icons';
+import { MoonIcon, SunIcon, LoadingIcon } from '~/components/icons';
 
 const themeOptions: ThemePreference[] = ['dark', 'light'];
 
@@ -26,7 +27,7 @@ export function ThemePicker() {
 		<Dropdown.Root>
 			<Dropdown.Trigger asChild>
 				<span
-					className="appearance-none cursor-pointer lg:scale-110"
+					className="appearance-none cursor-pointer lg:scale-110 p-[5px]"
 					tabIndex={0}
 				>
 					{themeIcon}
@@ -39,7 +40,7 @@ export function ThemePicker() {
 				{themeOptions.map((option) => (
 					<Dropdown.CheckItem
 						key={option}
-						className="capitalize cursor-pointer flex gap-3 items-center text-lg"
+						className="capitalize cursor-pointer flex gap-3 items-center text-lg pl-1"
 						checked={themePreference === option}
 						onCheckedChange={(checked) => {
 							if (checked) updateThemePreference(option);


### PR DESCRIPTION
The `outline` on the theme picker icons, especially in the dropdown menu, was too close and resulted in a bad visual. Adding a little padding to make it less claustrophobic.